### PR TITLE
Fix keyword

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
         {
             "id": "hash_kw",
             "type": "keyword",
-            "name": "Keyword",
+            "name": "Hash",
             "default_value": "hash"
         }
     ]


### PR DESCRIPTION
It seems keyword should be the full name of the plugin (ex: https://github.com/Ulauncher/ulauncher-kill/blob/master/manifest.json)

Otherwise when users type in "key" (as in for example "keyboard settings") they will get a row with "Keyword". Since I installed several of your very useful plugins I get four rows (apart from this one also `encode`, `decode` and `lipsum`)