### PR TITLE
Support utf-8 characters

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,11 +21,11 @@ class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
         items = []
    
-        md5Hash = hashlib.md5(event.get_argument()).hexdigest()
-        sha1Hash = hashlib.sha1(event.get_argument()).hexdigest()
-        sha224Hash = hashlib.sha224(event.get_argument()).hexdigest()
-        sha256Hash = hashlib.sha256(event.get_argument()).hexdigest()
-        sha512Hash = hashlib.sha512(event.get_argument()).hexdigest()
+        md5Hash = hashlib.md5(event.get_argument().encode('utf-8')).hexdigest()
+        sha1Hash = hashlib.sha1(event.get_argument().encode('utf-8')).hexdigest()
+        sha224Hash = hashlib.sha224(event.get_argument().encode('utf-8')).hexdigest()
+        sha256Hash = hashlib.sha256(event.get_argument().encode('utf-8')).hexdigest()
+        sha512Hash = hashlib.sha512(event.get_argument().encode('utf-8')).hexdigest()
         
         items.append(ExtensionResultItem(icon='images/icon.png',
                                          name=md5Hash,


### PR DESCRIPTION
I'm not a Python dev, but I googled this and used the result to fix #1 locally. Tested with the string suggested by @mjchow and the result verifies with `echo -n 你好 | sha1sum` and `echo -n 你好 | md5sum`. Non-unicode strings still works of course.