### PR TITLE
Support algos as keywords and show all supported algos in results

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,8 +20,14 @@ class KeywordQueryEventListener(EventListener):
         items = []
         argument = event.get_argument().encode('utf-8')
         keyword = event.get_keyword()
+
+        # Find the keyword id using the keyword (since the keyword can be changed by users)
+        for kwId, kw in extension.preferences.iteritems():
+            if kw == keyword:
+                keywordId = kwId[:-3] # Remove the "_kw" suffix
+
         # Show the algorithm specified as keyword, or all if the keyword was "hash"
-        algos = hashlib.algorithms if keyword == 'hash' else [keyword]
+        algos = hashlib.algorithms if keywordId == 'hash' else [keywordId]
 
         for algo in algos:
             hash = getattr(hashlib, algo)(argument).hexdigest()

--- a/main.py
+++ b/main.py
@@ -10,65 +10,24 @@ from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAct
 logger = logging.getLogger(__name__)
 
 class HashExtension(Extension):
-
     def __init__(self):
         logger.info('init hash Extension')
         super(HashExtension, self).__init__()
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
 
 class KeywordQueryEventListener(EventListener):
-
     def on_event(self, event, extension):
         items = []
-   
-        md5Hash = hashlib.md5(event.get_argument().encode('utf-8')).hexdigest()
-        sha1Hash = hashlib.sha1(event.get_argument().encode('utf-8')).hexdigest()
-        sha224Hash = hashlib.sha224(event.get_argument().encode('utf-8')).hexdigest()
-        sha256Hash = hashlib.sha256(event.get_argument().encode('utf-8')).hexdigest()
-        sha512Hash = hashlib.sha512(event.get_argument().encode('utf-8')).hexdigest()
-        
-        items.append(ExtensionResultItem(icon='images/icon.png',
-                                         name=md5Hash,
-                                         description='md5',
-                                         highlightable=False,
-                                         on_enter=CopyToClipboardAction(
-                                             md5Hash)
-                                         ))
+        argument = event.get_argument().encode('utf-8')
+        keyword = event.get_keyword()
+        # Show the algorithm specified as keyword, or all if the keyword was "hash"
+        algos = hashlib.algorithms if keyword == 'hash' else [keyword]
 
-        items.append(ExtensionResultItem(icon='images/icon.png',
-                                          name=sha1Hash,
-                                          description='sha1',
-                                          highlightable=False,
-                                          on_enter=CopyToClipboardAction(
-                                              sha1Hash)
-                                          ))
-
-
-        items.append(ExtensionResultItem(icon='images/icon.png',
-                                          name=sha224Hash,
-                                         description='sha224',
-                                         highlightable=False,
-                                         on_enter=CopyToClipboardAction(
-                                             sha224Hash)
-                                         ))
-        
-        items.append(ExtensionResultItem(icon='images/icon.png',
-                                          name=sha256Hash,
-                                          description='sha256',
-                                          highlightable=False,
-                                          on_enter=CopyToClipboardAction(
-                                              sha256Hash)
-                                          ))
-
-        items.append(ExtensionResultItem(icon='images/icon.png',
-                                         name=sha512Hash,
-                                         description='sha512',
-                                         highlightable=False,
-                                         on_enter=CopyToClipboardAction(
-                                              sha512Hash)
-                                         ))
+        for algo in algos:
+            hash = getattr(hashlib, algo)(argument).hexdigest()
+            items.append(ExtensionResultItem(icon='images/icon.png', name=hash, description=algo, highlightable=False, on_enter=CopyToClipboardAction(hash)))
 
         return RenderResultListAction(items)
 
 if __name__ == '__main__':
-   HashExtension().run()
+    HashExtension().run()

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ class HashExtension(Extension):
 class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
         items = []
-        argument = event.get_argument().encode('utf-8')
+        argument = (event.get_argument() or '').encode('utf-8')
         keyword = event.get_keyword()
 
         # Find the keyword id using the keyword (since the keyword can be changed by users)

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,42 @@
             "type": "keyword",
             "name": "Hash",
             "default_value": "hash"
+        },
+        {
+            "id": "md5_kw",
+            "type": "keyword",
+            "name": "md5",
+            "default_value": "md5"
+        },
+        {
+            "id": "sha1_kw",
+            "type": "keyword",
+            "name": "sha1",
+            "default_value": "sha1"
+        },
+        {
+            "id": "sha224_kw",
+            "type": "keyword",
+            "name": "sha224",
+            "default_value": "sha224"
+        },
+        {
+            "id": "sha256_kw",
+            "type": "keyword",
+            "name": "sha256",
+            "default_value": "sha256"
+        },
+        {
+            "id": "sha384_kw",
+            "type": "keyword",
+            "name": "sha384",
+            "default_value": "sha384"
+        },
+        {
+            "id": "sha512_kw",
+            "type": "keyword",
+            "name": "sha512",
+            "default_value": "sha512"
         }
     ]
 }


### PR DESCRIPTION
This is a rewrite. Even if most of the code is changed I didn't want to fork and add another competitor to the ecosystem.

1. The code in `KeywordQueryEventListener` is now dynamic with no code repetition
2. All algorithms in [hashlib.algorithms](https://docs.python.org/2/library/hashlib.html#hashlib.hashlib.algorithms) are now supported (same as before and the same order, except for adding `sha384`)
3. Algos can be used as keywords, so for example `md5 123` shows only the md5 hash, but `hash 123` shows all of them, like before.

![screenshot from 2018-09-06 15-08-05](https://user-images.githubusercontent.com/515120/45159329-c45fb080-b1e6-11e8-86a4-f0f1c9b66931.png)

![screenshot from 2018-09-06 15-09-13](https://user-images.githubusercontent.com/515120/45159389-ea855080-b1e6-11e8-9043-bc6cd79c022e.png)

![screenshot from 2018-09-06 14-33-32](https://user-images.githubusercontent.com/515120/45159324-bd38a280-b1e6-11e8-8ccb-8129b8fa2204.png)